### PR TITLE
Persisting last user selected Anr setting on connect

### DIFF
--- a/NoQCNoLife/AppDelegate.swift
+++ b/NoQCNoLife/AppDelegate.swift
@@ -25,6 +25,9 @@ import os.log
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     
+    // store last selected Anr mode
+    var lastSelectedAnrMode = Bose.AnrMode.OFF
+    
     var bt: Bt!
     var statusItem: StatusItem!
     var connectBtUserNotification: IOBluetoothUserNotification!
@@ -64,6 +67,9 @@ extension AppDelegate: BluetoothDelegate {
         print("[BT]: Connected to \(productID.getProductName())")
         #endif
         self.statusItem.connected(productID)
+        
+        // Persist last selected Anr mode on connect
+        noiseCancelModeSelected(lastSelectedAnrMode)
     }
     
     func onDisconnect() {
@@ -85,6 +91,11 @@ extension AppDelegate: BluetoothDelegate {
         print("[AnrModeEvent]: \(mode?.toString() ?? "nil")")
         #endif
         self.statusItem.setNoiseCancelMode(mode)
+        
+        // Update last selected Anr mode
+        if (mode != nil) {
+            lastSelectedAnrMode = mode!
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Persisting last user selected anr setting (across disconnect/reconnect)

## Why
Personally I really hate how bose qc35 always defaults to anr High setting every time I turn them on,
(and then you have to go into the phone app, bla bla bla). Most of the time I use mine with anr off.

## What I did
I added 3 lines to your code so that the last setting that was selected when headphones were disconnected,
will be set again when reconnected.

This is an adaptation i made for my own personal use case, 
I made this pull request in case you wanna add it back to yours aswell

## Thank You
Thank you for making this, I've been looking for something like this for about 3 Years!

Cheers!
